### PR TITLE
fix: 회원가입 페이지 유효성 검사 및 중복체크

### DIFF
--- a/src/pages/SignInPage/Category/CategoryGroup.jsx
+++ b/src/pages/SignInPage/Category/CategoryGroup.jsx
@@ -1,17 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import CategoryItem from './CategoryItem';
 
-export default function CategoryGroup({ title, contentArr, selectedCategory, setSelectedCategory }) {
+export default function CategoryGroup({ title, contentArr, category, setCategory }) {
   return (
     <div className="grid grid-cols-4 gap-4 mb-10 border-2 px-10 py-5 border-primary rounded-lg">
       <span className="col-span-4 text-center text-xl font-semibold">{title}</span>
       {contentArr?.map(content => (
-        <CategoryItem
-          key={content}
-          content={content}
-          selectedCategory={selectedCategory}
-          setSelectedCategory={setSelectedCategory}
-        />
+        <CategoryItem key={content} content={content} category={category} setCategory={setCategory} />
       ))}
     </div>
   );

--- a/src/pages/SignInPage/Category/CategoryItem.jsx
+++ b/src/pages/SignInPage/Category/CategoryItem.jsx
@@ -1,17 +1,17 @@
 import React, { useRef, useState } from 'react';
 
-export default function CategoryItem({ content, selectedCategory, setSelectedCategory }) {
+export default function CategoryItem({ content, category, setCategory }) {
   const categoryRef = useRef();
   const [isActive, setIsActive] = useState(false);
 
   const handleCategory = () => {
     // console.log(categoryRef.current.innerText);
     const categoryContent = categoryRef.current.innerText;
-    const isSelected = selectedCategory.includes(categoryContent);
+    const isSelected = category.includes(categoryContent);
     if (isSelected) {
-      setSelectedCategory(selectedCategory.filter(category => category !== categoryContent));
+      setCategory(category.filter(category => category !== categoryContent));
     } else {
-      setSelectedCategory([...selectedCategory, categoryContent]);
+      setCategory([...category, categoryContent]);
     }
     setIsActive(!isActive);
   };

--- a/src/pages/SignInPage/Category/index.jsx
+++ b/src/pages/SignInPage/Category/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import CategoryGroup from './CategoryGroup';
 
-export default function Category({ selectedCategory, setSelectedCategory }) {
+export default function Category({ category, setCategory }) {
   const studentArr = ['초등학생', '중학생', '고등학생', '대학생'];
   const publicArr = ['경찰', '소방관', '행정고시', '군인'];
   return (
@@ -10,18 +10,8 @@ export default function Category({ selectedCategory, setSelectedCategory }) {
         <h2 className="font-bold text-2xl">어떤 부분에 관심 있으세요?</h2>
       </div>
       <div className="categoryWrap flex flex-col">
-        <CategoryGroup
-          title={'학생'}
-          contentArr={studentArr}
-          selectedCategory={selectedCategory}
-          setSelectedCategory={setSelectedCategory}
-        />
-        <CategoryGroup
-          title={'공무원'}
-          contentArr={publicArr}
-          selectedCategory={selectedCategory}
-          setSelectedCategory={setSelectedCategory}
-        />
+        <CategoryGroup title={'학생'} contentArr={studentArr} category={category} setCategory={setCategory} />
+        <CategoryGroup title={'공무원'} contentArr={publicArr} category={category} setCategory={setCategory} />
       </div>
     </div>
   );

--- a/src/pages/SignInPage/NickName/index.jsx
+++ b/src/pages/SignInPage/NickName/index.jsx
@@ -1,26 +1,36 @@
 import React, { useState } from 'react';
-import Button from '../../../components/common/Button';
+// import Button from '../../../components/common/Button';
 import { API } from '../../../utils/axios';
 
-export default function NickName({ nickName, setNickName }) {
+export default function NickName({ nickName, setNickName, isDuplicate, setIsDuplicate, isValidate, setIsValidate }) {
   const [message, setMessage] = useState('');
   const handleCheckDuplicate = async () => {
     // 중복체크
     const res = await API.get(`/user/nick/${nickName}/duplicateCheck`);
-    // const res = { data: true };
     setMessage(!res.data ? '사용 가능' : '닉네임 중복');
+    setIsDuplicate(!res.data ? false : true);
   };
   const handleInputChange = e => {
+    // 닉네임 입력 시 닉네임 상태값 설정하고 메세지는 초기화
     setNickName(e.target.value);
     setMessage('');
   };
   const handleBlur = () => {
+    // input 창에서 나오면 유효성 검사
     const pattern = /^[A-Za-z0-9가-힣]{2,10}$/;
-    if (!pattern.test(nickName)) {
-      setMessage('닉네임은 한글, 영문, 숫자를 포함한 2~10자 이하입니다!');
+    if (nickName) {
+      // 닉네임에 값이 있을 때에만 유효성 검사
+      if (!pattern.test(nickName)) {
+        setMessage('닉네임은 한글, 영문, 숫자를 포함한 2~10자 이하입니다!');
+        setIsValidate(false);
+      } else {
+        setIsValidate(true);
+      }
     }
   };
-  const styled = message === '사용 가능' ? 'text-primary' : 'text-red-600';
+  // 중복, 유효성 상태에 따른 스타일
+  const messageStyled = !isDuplicate ? 'text-primary' : 'text-red-600';
+  const buttonStyled = isValidate ? '!bg-primary' : '!bg-gray-500';
   return (
     <div className="nickContainer mb-10 flex justify-start items-center">
       <div className="nickTitle me-3">
@@ -36,9 +46,16 @@ export default function NickName({ nickName, setNickName }) {
           onChange={handleInputChange}
           onBlur={handleBlur}
         />
-        <Button handleClick={handleCheckDuplicate}>중복체크</Button>
+        {/* <Button handleClick={handleCheckDuplicate}>중복체크</Button> */}
+        <button
+          className={`text-white w-fit text-sm leading-6 font-bold tracking-wider py-[5px] px-2.5 rounded-lg ${buttonStyled}`}
+          onClick={handleCheckDuplicate}
+          disabled={isValidate ? false : true}
+        >
+          중복체크
+        </button>
       </div>
-      {message && <span className={`font-semibold ms-5 ${styled}`}>{message}</span>}
+      {message && <span className={`font-semibold ms-5 ${messageStyled}`}>{message}</span>}
     </div>
   );
 }

--- a/src/pages/SignInPage/index.jsx
+++ b/src/pages/SignInPage/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import Button from '../../components/common/Button';
 import { useDispatch } from 'react-redux';
 import { profileUser } from '../../reducers/thunkFunctions';
@@ -7,30 +7,48 @@ import Category from './Category';
 import NickName from './NickName';
 
 export default function SignInPage() {
-  const [selectedCategory, setSelectedCategory] = useState([]);
+  const [category, setCategory] = useState([]);
   const [nickName, setNickName] = useState('');
+  const [isDuplicate, setIsDuplicate] = useState(true);
+  const [isValidate, setIsValidate] = useState(false);
+
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
   // 유저 정보 수정
   const handleUserInfo = async () => {
-    dispatch(profileUser({ category: selectedCategory[0], nickName: nickName }));
-    alert(`환영합니다 ${nickName}님!`);
-    navigate('/');
+    if (isDuplicate && !category) {
+      alert('중복 체크 및 카테고리 선택을 해주세요!');
+    } else if (isDuplicate) {
+      alert('');
+    } else {
+      dispatch(profileUser({ category: category[0], nickName: nickName }));
+      await alert(`환영합니다 ${nickName}님!`);
+      navigate('/');
+    }
   };
   return (
     <div className="flex flex-col justify-center h-screen">
       <div className="titleWrap flex justify-between mb-10">
         <h1 className="font-bold text-3xl underline underline-offset-8 decoration-sky-500">카테고리 및 닉네임 설정</h1>
-        <Button
-          handleClick={handleUserInfo}
-          customStyle="border-2 p-3 self-end bg-transparent !text-primary border-primary border-2 text-lg"
-        >
-          완료
-        </Button>
+        {isValidate && !isDuplicate && category.length > 0 && (
+          <Button
+            handleClick={handleUserInfo}
+            customStyle={`border-2 p-3 self-end bg-transparent !text-primary border-primary border-2 text-lg`}
+          >
+            완료
+          </Button>
+        )}
       </div>
-      <NickName nickName={nickName} setNickName={setNickName} />
-      <Category selectedCategory={selectedCategory} setSelectedCategory={setSelectedCategory} />
+      <NickName
+        nickName={nickName}
+        setNickName={setNickName}
+        isDuplicate={isDuplicate}
+        setIsDuplicate={setIsDuplicate}
+        isValidate={isValidate}
+        setIsValidate={setIsValidate}
+      />
+      <Category category={category} setCategory={setCategory} />
     </div>
   );
 }


### PR DESCRIPTION
1. 닉네임 유효성 검사(2~10자 이하 등) 통과해야 중복체크 가능하게 수정
2. 닉네임이 유효하고 중복도 아니고 카테고리 값이 있을 때에 완료 버튼 뜨게 수정
3. 닉네임 input이 빈값일 때에는 유효성 검사 메세지 안 뜨게 수정