### PR TITLE
feat: 카카오 소셜 로그인 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,9 @@ import ProfilePage from './pages/ProfilePage';
 import CalendarPage from './pages/CalendarPage';
 import { io } from 'socket.io-client';
 import ZoomPage from './pages/ZoomPage';
+import KakaoPage from './pages/OAuthPage/KakaoPage';
+import GooglePage from './pages/OAuthPage/GooglePage';
+import NaverPage from './pages/OAuthPage/NaverPage';
 
 function App() {
   const isAuth = useAppSelector(state => state.user.isAuth);
@@ -63,6 +66,9 @@ function App() {
         <Route path="/notice" element={<NoticePage isServiceAdmin={isServiceAdmin} />} />
         <Route path="/notice/:noticeId" element={<DetailNoticePage isServiceAdmin={isServiceAdmin} />} />
         <Route path="/zoom" element={<ZoomPage />} />
+        <Route path="/oauth/kakao" element={<KakaoPage />} />
+        <Route path="/oauth/google" element={<GooglePage />} />
+        <Route path="/oauth/naver" element={<NaverPage />} />
         <Route element={<NotAdminRoutes isServiceAdmin={isServiceAdmin} />}>
           <Route path="/notice/create" element={<CreateNoticePage />} />
         </Route>

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -3,6 +3,10 @@ import { useAppDispatch, useAppSelector } from '../store/store';
 import { loginUser } from '../store/thunkFunctions';
 import Modal from './common/Modal';
 import { useForm, SubmitHandler } from 'react-hook-form';
+import { RiKakaoTalkFill } from 'react-icons/ri';
+import { FcGoogle } from 'react-icons/fc';
+import { SiNaver } from 'react-icons/si';
+import { redirectUrl } from '../utils/redirectUrl';
 
 type FormValues = {
   email: string;
@@ -30,6 +34,33 @@ export default function LoginModal({ open, onClose }: ModalProps) {
       onClose(false);
     }
   }, [isAuth, reset, onClose]);
+
+  // 소셜 로그인
+  // API & Redirect URI
+  const KAKAO_REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
+  const KAKAO_REDIRECT_URI = redirectUrl('kakao');
+  const KAKAO_LOGIN_URI = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_REST_API_KEY}&redirect_uri=${KAKAO_REDIRECT_URI}&response_type=code`;
+
+  const NAVER_CLIENT_ID = import.meta.env.VITE_NAVER_CLIENT_ID;
+  const NAVER_STATE = import.meta.env.VITE_NAVER_STATE;
+  const NAVER_REDIRECT_URI = redirectUrl('naver');
+  const NAVER_LOGIN_URI = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${NAVER_CLIENT_ID}&redirect_uri=${NAVER_REDIRECT_URI}&state=${NAVER_STATE}`;
+
+  const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+  const GOOGLE_REDIRECT_URL = redirectUrl('google');
+  const GOOGLE_LOGIN_URI = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${GOOGLE_REDIRECT_URL}&response_type=code&scope=email profile`;
+
+  // style
+  // const kakaoColor = '#FEE500';
+  // const googleColor = '#fefefe';
+  // const naverColor = '#2DB400';
+  const kakaoStyle = `w-full mb-2 box-border flex items-center text-md leading-6 font-bold tracking-wider py-[10px] px-2.5 rounded-lg !bg-[#FEE500] !text-[#3D1D1E]`;
+  const googleStyle = `w-full mb-2 box-border flex items-center !text-black text-md leading-6 font-bold tracking-wider py-[10px] px-2.5 rounded-lg !bg-[#fefefe]`;
+  const naverStyle = `w-full mb-2 box-border flex items-center text-md leading-6 font-bold tracking-wider py-[10px] px-2.5 rounded-lg !bg-[#2DB400]`;
+
+  const handleNavigate = (uri: string) => {
+    window.location.href = uri;
+  };
 
   return (
     <Modal show={open} onClose={onClose}>
@@ -89,6 +120,19 @@ export default function LoginModal({ open, onClose }: ModalProps) {
               </button>
             </div>
           </form>
+          {/* 소셜 로그인 */}
+          <button onClick={() => handleNavigate(`${KAKAO_LOGIN_URI}`)} className={kakaoStyle}>
+            <RiKakaoTalkFill size={25} />
+            <span className="ms-3">카카오 로그인</span>
+          </button>
+          <button onClick={() => handleNavigate(`${GOOGLE_LOGIN_URI}`)} className={googleStyle}>
+            <FcGoogle size={25} />
+            <span className="ms-3">구글 로그인</span>
+          </button>
+          <button onClick={() => handleNavigate(`${NAVER_LOGIN_URI}`)} className={naverStyle}>
+            <SiNaver size={25} />
+            <span className="ms-3">네이버 로그인</span>
+          </button>
         </div>
       </div>
     </Modal>

--- a/src/pages/OAuthPage/GooglePage.tsx
+++ b/src/pages/OAuthPage/GooglePage.tsx
@@ -1,0 +1,64 @@
+import axios from 'axios';
+import { useCallback, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAppDispatch } from '../../store/store';
+import { redirectUrl } from '../../utils/redirectUrl';
+import { loginUser } from '../../store/thunkFunctions';
+
+export default function GooglePage() {
+  const navigate = useNavigate();
+  const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+  const GOOGLE_CLIENT_SECRET = import.meta.env.VITE_GOOGLE_CLIENT_SECRET;
+
+  const REDIRECT_URI = redirectUrl('google');
+  const dispatch = useAppDispatch();
+
+  const getToken = useCallback(
+    async (code: string) => {
+      try {
+        const response = await axios.post('https://oauth2.googleapis.com/token', {
+          code,
+          client_id: GOOGLE_CLIENT_ID,
+          client_secret: GOOGLE_CLIENT_SECRET,
+          redirect_uri: REDIRECT_URI,
+          grant_type: 'authorization_code',
+        });
+
+        const { access_token } = response.data;
+        const profile = await getFirebaseCustomToken(access_token);
+        profile.provider = 'google';
+
+        // 리덕스에서 로그인 로직 처리 후 리덕스로 상태관리
+        dispatch(loginUser(profile));
+        navigate('/');
+      } catch (err) {
+        console.log(err);
+      }
+    },
+    [GOOGLE_CLIENT_ID, REDIRECT_URI, navigate, dispatch]
+  );
+
+  const getFirebaseCustomToken = async (access_token: string) => {
+    try {
+      const response = await axios.get('https://www.googleapis.com/oauth2/v2/userinfo', {
+        headers: {
+          Authorization: `Bearer ${access_token}`,
+        },
+      });
+
+      const profile = response.data;
+      return profile;
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  useEffect(() => {
+    const code = new URL(window.location.href).searchParams.get('code');
+    if (code) {
+      getToken(code);
+    }
+  }, [getToken]);
+
+  return <div>Google 로그인 중...</div>;
+}

--- a/src/pages/OAuthPage/KakaoPage.tsx
+++ b/src/pages/OAuthPage/KakaoPage.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { loginUser } from '../../store/thunkFunctions';
+import { socialRefreshUser, socialUser } from '../../store/thunkFunctions';
 import { redirectUrl } from '../../utils/redirectUrl';
 import { useAppDispatch } from '../../store/store';
 
@@ -23,13 +23,16 @@ export default function KakaoPage() {
             code,
           },
         });
+        // console.log('토큰값:: ', response.data);
 
         const { access_token } = response.data;
         const profile = await getFirebaseCustomToken(access_token);
         profile.provider = 'kakao';
 
+        // console.log('최종 profile :: ', profile);
         // 리덕스에서 로그인 로직 처리 후 리덕스로 상태관리
-        dispatch(loginUser(profile));
+        await dispatch(socialUser(profile));
+        dispatch(socialRefreshUser());
         navigate('/');
       } catch (err) {
         console.log(err);
@@ -45,6 +48,7 @@ export default function KakaoPage() {
           Authorization: `Bearer ${access_token}`,
         },
       });
+      // console.log('두번째 토큰값::', response.data);
 
       const profile = response.data;
       return profile;
@@ -55,6 +59,7 @@ export default function KakaoPage() {
 
   useEffect(() => {
     const code = new URL(window.location.href).searchParams.get('code');
+    // console.log(code);
     if (code) {
       getToken(code);
     }

--- a/src/pages/OAuthPage/KakaoPage.tsx
+++ b/src/pages/OAuthPage/KakaoPage.tsx
@@ -1,0 +1,64 @@
+import axios from 'axios';
+import { useCallback, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { loginUser } from '../../store/thunkFunctions';
+import { redirectUrl } from '../../utils/redirectUrl';
+import { useAppDispatch } from '../../store/store';
+
+export default function KakaoPage() {
+  const navigate = useNavigate();
+  const KAKAO_REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
+
+  const REDIRECT_URI = redirectUrl('kakao');
+  const dispatch = useAppDispatch();
+
+  const getToken = useCallback(
+    async (code: string) => {
+      try {
+        const response = await axios.post('https://kauth.kakao.com/oauth/token', null, {
+          params: {
+            grant_type: 'authorization_code',
+            client_id: KAKAO_REST_API_KEY,
+            redirect_uri: REDIRECT_URI,
+            code,
+          },
+        });
+
+        const { access_token } = response.data;
+        const profile = await getFirebaseCustomToken(access_token);
+        profile.provider = 'kakao';
+
+        // 리덕스에서 로그인 로직 처리 후 리덕스로 상태관리
+        dispatch(loginUser(profile));
+        navigate('/');
+      } catch (err) {
+        console.log(err);
+      }
+    },
+    [KAKAO_REST_API_KEY, REDIRECT_URI, navigate, dispatch]
+  );
+
+  const getFirebaseCustomToken = async (access_token: string) => {
+    try {
+      const response = await axios.get('https://kapi.kakao.com/v2/user/me', {
+        headers: {
+          Authorization: `Bearer ${access_token}`,
+        },
+      });
+
+      const profile = response.data;
+      return profile;
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  useEffect(() => {
+    const code = new URL(window.location.href).searchParams.get('code');
+    if (code) {
+      getToken(code);
+    }
+  }, [getToken]);
+
+  return <div>Kakao 로그인 중...</div>;
+}

--- a/src/pages/OAuthPage/NaverPage.tsx
+++ b/src/pages/OAuthPage/NaverPage.tsx
@@ -1,0 +1,77 @@
+import axios from 'axios';
+import { useCallback, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { loginUser } from '../../store/thunkFunctions';
+import { useAppDispatch } from '../../store/store';
+
+import { redirectUrl } from '../../utils/redirectUrl';
+
+export default function NaverPage() {
+  const navigate = useNavigate();
+  const NAVER_CLIENT_ID = import.meta.env.VITE_NAVER_CLIENT_ID;
+  // const NAVER_CLIENT_SECRET = import.meta.env.VITE_NAVER_CLIENT_SECRET;
+  const NAVER_BACKEND_API = import.meta.env.VITE_NAVER_BACKEND_API;
+
+  const REDIRECT_URI = redirectUrl('naver');
+  const dispatch = useAppDispatch();
+
+  const getToken = useCallback(
+    async (code: string, state: string) => {
+      try {
+        const data = {
+          code: code,
+          state: state,
+        };
+
+        const response = await axios.post(NAVER_BACKEND_API, data);
+        // const accessToken = response.data.naverTokens;
+
+        const profile = response.data.naverUser.response;
+        profile.provider = 'naver';
+
+        // 리덕스에서 로그인 로직 처리 후 리덕스로 상태관리
+        dispatch(loginUser(profile));
+        navigate('/');
+      } catch (err) {
+        console.log(err);
+      }
+    },
+    [NAVER_CLIENT_ID, REDIRECT_URI, navigate, dispatch]
+  );
+
+  // const getFirebaseCustomToken = async access_token => {
+  //   try {
+  //     const response = await axios.get('https://openapi.naver.com/v1/nid/me', {
+  //       headers: {
+  //         Authorization: `Bearer ${access_token}`,
+  //       },
+  //     });
+  //     // console.log('?????', response);
+  //     const profile = response.data;
+  //     // profile Example
+  //     // {
+  //     // "resultcode":"00",
+  //     // "message":"success",
+  //     // "response":{
+  //     //     "id":"7bvETqfH2_eL9tTtDAqFI8ejYYOGepMtlLEk1zaJjO4",
+  //     //     "email":"edcba1234@naver.com" // 없을수도 있음(필수아니라)
+  //     //     }
+  //     // }
+  //     return profile;
+  //   } catch (err) {
+  //     console.log(err);
+  //   }
+  // };
+
+  useEffect(() => {
+    // const code = new URL(window.location.href).searchParams.get('code');
+    const url = new URL(window.location.href);
+    const code = url.searchParams.get('code');
+    const state = url.searchParams.get('state');
+    if (code && state) {
+      getToken(code, state);
+    }
+  }, [getToken]);
+
+  return <div>Naver 로그인 중...</div>;
+}

--- a/src/store/thunkFunctions.ts
+++ b/src/store/thunkFunctions.ts
@@ -1,4 +1,4 @@
-import { API } from '../utils/axios';
+import { API, AUTH } from '../utils/axios';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 interface CustomError extends Error {
@@ -26,6 +26,19 @@ export const loginUser = createAsyncThunk('user/loginUser', async (body: object,
   }
 });
 
+export const socialUser = createAsyncThunk('user/socialUser', async (body: object, thunkAPI) => {
+  try {
+    // const response = await API.post(`/user/join?provider=${provider}`, body);
+    const response = await API.post(`/user/kakaologin`, body);
+
+    return response.data;
+  } catch (error: unknown) {
+    const customErr = error as CustomError;
+    console.log(customErr);
+    return thunkAPI.rejectWithValue(customErr.response?.data || customErr.message);
+  }
+});
+
 export const authUser = createAsyncThunk('user/authUser', async (_, thunkAPI) => {
   try {
     const response = await API.get(`/user`);
@@ -40,6 +53,18 @@ export const authUser = createAsyncThunk('user/authUser', async (_, thunkAPI) =>
 export const profileUser = createAsyncThunk('user/profileUser', async (body: object, thunkAPI) => {
   try {
     const response = await API.patch('/user/profile', body);
+    console.log(response);
+    return response.data;
+  } catch (error: unknown) {
+    const customErr = error as CustomError;
+    console.log(customErr);
+    return thunkAPI.rejectWithValue(customErr.response?.data || customErr.message);
+  }
+});
+
+export const socialRefreshUser = createAsyncThunk('auth/socialRefreshUser', async (_, thunkAPI) => {
+  try {
+    const response = await AUTH.get('/auth/refresh');
     console.log(response);
     return response.data;
   } catch (error: unknown) {

--- a/src/store/userSlice.ts
+++ b/src/store/userSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
-import { authUser, profileUser, loginUser, deleteAlarm } from './thunkFunctions';
+import { authUser, profileUser, loginUser, deleteAlarm, socialUser, socialRefreshUser } from './thunkFunctions';
 import { toast } from 'react-toastify';
 
 interface UserState {
@@ -55,6 +55,36 @@ const userSlice = createSlice({
         localStorage.setItem('accessToken', action.payload.accessToken);
       })
       .addCase(loginUser.rejected, (state, action: any) => {
+        state.isLoading = false;
+        state.error = action.payload;
+        toast.info('로그인 정보를 확인 해주세요!', { type: toast.TYPE.ERROR });
+      })
+      .addCase(socialUser.pending, state => {
+        state.isLoading = true;
+      })
+      .addCase(socialUser.fulfilled, (state, action: PayloadAction<{ userInfo: UserInfo; refreshToken: string }>) => {
+        state.isLoading = false;
+        state.error = '';
+        localStorage.setItem('refreshToken', action.payload.refreshToken);
+      })
+      .addCase(socialUser.rejected, (state, action: any) => {
+        state.isLoading = false;
+        state.error = action.payload;
+        toast.info('로그인 정보를 확인 해주세요!', { type: toast.TYPE.ERROR });
+      })
+      .addCase(socialRefreshUser.pending, state => {
+        state.isLoading = true;
+      })
+      .addCase(
+        socialRefreshUser.fulfilled,
+        (state, action: PayloadAction<{ userInfo: UserInfo; accessToken: string }>) => {
+          state.isLoading = false;
+          state.isAuth = true;
+          state.error = '';
+          localStorage.setItem('accessToken', action.payload.accessToken);
+        }
+      )
+      .addCase(socialRefreshUser.rejected, (state, action: any) => {
         state.isLoading = false;
         state.error = action.payload;
         toast.info('로그인 정보를 확인 해주세요!', { type: toast.TYPE.ERROR });

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -27,3 +27,31 @@ API.interceptors.response.use(
     return Promise.reject(error);
   }
 );
+
+export const AUTH = axios.create({
+  // baseURL: import.meta.env.PROD ? apiUrl() : import.meta.env.VITE_APP_API_URL,
+  baseURL: 'http://localhost:8001/api',
+});
+
+AUTH.interceptors.request.use(
+  function (config) {
+    config.headers.Authorization = 'Bearer ' + localStorage.getItem('refreshToken');
+    return config;
+  },
+  function (error) {
+    return Promise.reject(error);
+  }
+);
+
+AUTH.interceptors.response.use(
+  function (response) {
+    return response;
+  },
+  function (error) {
+    if (error.response.data.msg === '토큰 만료') {
+      window.location.reload();
+    }
+
+    return Promise.reject(error);
+  }
+);


### PR DESCRIPTION
1. axios.ts 파일에 AUTH 모듈 추가
2. thunk socialUser, socialRefreshUser 추가 : 카카오 서버로부터 액세스 토큰 발급받으면 그걸로 리프레시 토큰 발급 받아서 두단계에 걸쳐 인증하는 과정 필요 -> 리프레시 토큰으로 검증 되면 다시 액세스 토큰 받아서 isAuth를 true로 설정하고 authUser dispatch 가능